### PR TITLE
Revert on non zero exit code

### DIFF
--- a/libraries/koinos_api_cpp/include/koinos/system/system_calls.hpp
+++ b/libraries/koinos_api_cpp/include/koinos/system/system_calls.hpp
@@ -145,6 +145,7 @@ using head_info = koinos::chain::head_info< detail::max_hash_size, detail::max_h
 
 inline void log( const std::string& );
 inline void exit( const result& r );
+inline void revert( const std::string& msg = "" );
 
 // General Blockchain Management
 
@@ -157,7 +158,7 @@ inline head_info get_head_info()
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::get_head_info ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -165,6 +166,9 @@ inline head_info get_head_info()
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 
    koinos::read_buffer rdbuf( detail::syscall_buffer.data(), bytes_written );
 
@@ -363,7 +367,7 @@ inline bool process_block_signature( const std::string& digest, const block_head
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::process_block_signature ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -371,6 +375,9 @@ inline bool process_block_signature( const std::string& digest, const block_head
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 
    koinos::read_buffer rdbuf( detail::syscall_buffer.data(), bytes_written );
 
@@ -390,7 +397,7 @@ inline value_type get_transaction_field( const std::string& field )
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::get_transaction_field ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -398,6 +405,9 @@ inline value_type get_transaction_field( const std::string& field )
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 
    koinos::read_buffer rdbuf( detail::syscall_buffer.data(), bytes_written );
 
@@ -417,7 +427,7 @@ inline value_type get_block_field( const std::string& field )
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::get_block_field ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -425,6 +435,9 @@ inline value_type get_block_field( const std::string& field )
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 
    koinos::read_buffer rdbuf( detail::syscall_buffer.data(), bytes_written );
 
@@ -443,7 +456,7 @@ inline uint64_t get_last_irreversible_block()
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::get_last_irreversible_block ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -451,6 +464,9 @@ inline uint64_t get_last_irreversible_block()
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 
    koinos::read_buffer rdbuf( detail::syscall_buffer.data(), bytes_written );
 
@@ -469,7 +485,7 @@ inline std::string get_account_nonce( const std::string& account )
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::get_account_nonce ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -477,6 +493,9 @@ inline std::string get_account_nonce( const std::string& account )
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 
    koinos::read_buffer rdbuf( detail::syscall_buffer.data(), bytes_written );
 
@@ -495,7 +514,7 @@ inline bool check_system_authority( koinos::chain::system_authorization_type typ
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::check_system_authority ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -503,6 +522,9 @@ inline bool check_system_authority( koinos::chain::system_authorization_type typ
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 
    koinos::read_buffer rdbuf( detail::syscall_buffer.data(), bytes_written );
 
@@ -524,7 +546,7 @@ inline uint64_t get_account_rc( const std::string& account )
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::get_account_rc ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -532,6 +554,9 @@ inline uint64_t get_account_rc( const std::string& account )
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 
    koinos::read_buffer rdbuf( detail::syscall_buffer.data(), bytes_written );
 
@@ -573,7 +598,7 @@ inline void put_object( const object_space& space, const std::string& key, const
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::put_object ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -581,6 +606,9 @@ inline void put_object( const object_space& space, const std::string& key, const
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 }
 
 inline std::string get_object( const object_space& space, const std::string& key, uint32_t object_size_hint = 0 )
@@ -604,7 +632,7 @@ inline std::string get_object( const object_space& space, const std::string& key
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::get_object ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -612,6 +640,9 @@ inline std::string get_object( const object_space& space, const std::string& key
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 
    koinos::read_buffer rdbuf( detail::syscall_buffer.data(), bytes_written );
 
@@ -667,7 +698,7 @@ inline void remove_object( const object_space& space, const std::string& key )
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::remove_object ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -675,6 +706,9 @@ inline void remove_object( const object_space& space, const std::string& key )
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 }
 
 inline std::string get_next_object( const object_space& space, const std::string& key )
@@ -688,7 +722,7 @@ inline std::string get_next_object( const object_space& space, const std::string
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::get_next_object ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -696,6 +730,9 @@ inline std::string get_next_object( const object_space& space, const std::string
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 
    koinos::read_buffer rdbuf( detail::syscall_buffer.data(), bytes_written );
 
@@ -716,7 +753,7 @@ inline std::string get_prev_object( const object_space& space, const std::string
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::get_prev_object ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -724,6 +761,9 @@ inline std::string get_prev_object( const object_space& space, const std::string
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 
    koinos::read_buffer rdbuf( detail::syscall_buffer.data(), bytes_written );
 
@@ -745,7 +785,7 @@ inline void log( const std::string& s )
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::log ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -753,6 +793,9 @@ inline void log( const std::string& s )
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 }
 
 template< typename T >
@@ -788,7 +831,7 @@ inline void event( const std::string& name, const T& data, const std::vector< st
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::event ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -796,6 +839,9 @@ inline void event( const std::string& name, const T& data, const std::vector< st
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 }
 
 // Cryptography
@@ -812,7 +858,7 @@ inline std::string hash( uint64_t code, const std::string& obj, uint64_t size = 
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::hash ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -820,6 +866,9 @@ inline std::string hash( uint64_t code, const std::string& obj, uint64_t size = 
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 
    koinos::read_buffer rdbuf( detail::syscall_buffer.data(), bytes_written );
 
@@ -841,7 +890,7 @@ inline std::string recover_public_key( const std::string& signature, const std::
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::recover_public_key ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -849,6 +898,9 @@ inline std::string recover_public_key( const std::string& signature, const std::
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 
    koinos::read_buffer rdbuf( detail::syscall_buffer.data(), bytes_written );
 
@@ -878,7 +930,7 @@ inline bool verify_merkle_root( const std::string& root, const std::vector< std:
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::verify_merkle_root ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -886,6 +938,9 @@ inline bool verify_merkle_root( const std::string& root, const std::vector< std:
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 
    koinos::read_buffer rdbuf( detail::syscall_buffer.data(), bytes_written );
 
@@ -912,7 +967,7 @@ inline bool verify_signature( chain::dsa type, const std::string& public_key, co
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::verify_signature ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -920,6 +975,9 @@ inline bool verify_signature( chain::dsa type, const std::string& public_key, co
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 
    koinos::read_buffer rdbuf( detail::syscall_buffer.data(), bytes_written );
 
@@ -969,7 +1027,7 @@ inline std::pair< uint32_t, std::string > get_arguments()
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::get_arguments ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -977,6 +1035,9 @@ inline std::pair< uint32_t, std::string > get_arguments()
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 
    koinos::read_buffer rdbuf( detail::syscall_buffer.data(), bytes_written );
 
@@ -986,7 +1047,7 @@ inline std::pair< uint32_t, std::string > get_arguments()
    return std::make_pair( res.get_value().entry_point(), std::string( reinterpret_cast< const char* >( res.get_value().get_arguments().get_const() ), res.get_value().get_arguments().get_length() ) );
 }
 
-inline void revert( const std::string& msg = "" )
+inline void revert( const std::string& msg )
 {
    result r;
    r.set_code( 1 );
@@ -1024,7 +1085,7 @@ inline void exit( const result& r )
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::exit ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -1032,6 +1093,9 @@ inline void exit( const result& r )
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 }
 
 inline std::string get_contract_id()
@@ -1043,7 +1107,7 @@ inline std::string get_contract_id()
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::get_contract_id ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -1051,6 +1115,9 @@ inline std::string get_contract_id()
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 
    koinos::read_buffer rdbuf( detail::syscall_buffer.data(), bytes_written );
 
@@ -1069,7 +1136,7 @@ inline std::pair< std::string, koinos::chain::privilege > get_caller()
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::get_caller ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -1077,6 +1144,9 @@ inline std::pair< std::string, koinos::chain::privilege > get_caller()
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 
    koinos::read_buffer rdbuf( detail::syscall_buffer.data(), bytes_written );
 
@@ -1098,7 +1168,7 @@ inline bool check_authority( const std::string& account )
 
    uint32_t bytes_written = 0;
 
-   invoke_system_call(
+   int32_t retval = invoke_system_call(
       std::underlying_type_t< koinos::chain::system_call_id >( koinos::chain::system_call_id::check_authority ),
       reinterpret_cast< char* >( detail::syscall_buffer.data() ),
       std::size( detail::syscall_buffer ),
@@ -1106,6 +1176,9 @@ inline bool check_authority( const std::string& account )
       buffer.get_size(),
       &bytes_written
    );
+
+   if ( retval )
+      revert( std::string( reinterpret_cast< char* >( buffer.data() ), bytes_written ) );
 
    koinos::read_buffer rdbuf( detail::syscall_buffer.data(), bytes_written );
 


### PR DESCRIPTION
Resolves koinos/koinos-chain#671

## Brief description

Reverts when system calls return failure

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

Ran with a KOIN contract build with the updated SDK

```
ctest -j8
Test project /Users/mdv/git/koinos-chain/build/tests
      Start  6: koinos_tests-controller_tests/receipt_test
      Start 38: koinos_tests-thunk_tests/token_tests
      Start 43: koinos_tests-thunk_tests/thunk_time
      Start  3: koinos_tests-controller_tests/fork_heads
      Start  5: koinos_tests-controller_tests/transaction_reversion_test
      Start  2: koinos_tests-controller_tests/block_irreversibility
      Start 41: koinos_tests-thunk_tests/authorize_tests
      Start 15: koinos_tests-state_db_tests/fork_tests
 1/43 Test  #6: koinos_tests-controller_tests/receipt_test ........................   Passed    0.32 sec
      Start  4: koinos_tests-controller_tests/read_contract_tests
 2/43 Test #38: koinos_tests-thunk_tests/token_tests ..............................   Passed    0.40 sec
      Start 12: koinos_tests-stack_tests/syscall_override_from_syscall_override
 3/43 Test #15: koinos_tests-state_db_tests/fork_tests ............................   Passed    0.35 sec
      Start 13: koinos_tests-stack_tests/system_contract_from_syscall_override
 4/43 Test  #4: koinos_tests-controller_tests/read_contract_tests .................   Passed    0.13 sec
      Start  9: koinos_tests-stack_tests/syscall_from_user
 5/43 Test #13: koinos_tests-stack_tests/system_contract_from_syscall_override ....   Passed    0.15 sec
      Start  1: koinos_tests-controller_tests/submission_tests
 6/43 Test  #9: koinos_tests-stack_tests/syscall_from_user ........................   Passed    0.13 sec
      Start 27: koinos_tests-thunk_tests/override_tests
 7/43 Test #12: koinos_tests-stack_tests/syscall_override_from_syscall_override ...   Passed    0.21 sec
      Start  8: koinos_tests-stack_tests/simple_user_contract
 8/43 Test  #1: koinos_tests-controller_tests/submission_tests ....................   Passed    0.08 sec
      Start  7: koinos_tests-controller_tests/system_call_override_test
 9/43 Test #27: koinos_tests-thunk_tests/override_tests ...........................   Passed    0.10 sec
      Start 10: koinos_tests-stack_tests/user_from_user
10/43 Test  #2: koinos_tests-controller_tests/block_irreversibility ...............   Passed    0.68 sec
      Start 39: koinos_tests-thunk_tests/tick_limit
11/43 Test  #8: koinos_tests-stack_tests/simple_user_contract .....................   Passed    0.17 sec
      Start 16: koinos_tests-state_db_tests/merge_iterator
12/43 Test #41: koinos_tests-thunk_tests/authorize_tests ..........................   Passed    0.78 sec
      Start 11: koinos_tests-stack_tests/syscall_override_from_thunk
13/43 Test  #7: koinos_tests-controller_tests/system_call_override_test ...........   Passed    0.22 sec
      Start 17: koinos_tests-state_db_tests/reset_test
14/43 Test #39: koinos_tests-thunk_tests/tick_limit ...............................   Passed    0.17 sec
      Start 26: koinos_tests-thunk_tests/contract_tests
15/43 Test #10: koinos_tests-stack_tests/user_from_user ...........................   Passed    0.26 sec
      Start 25: koinos_tests-thunk_tests/db_crud
16/43 Test #17: koinos_tests-state_db_tests/reset_test ............................   Passed    0.13 sec
      Start 40: koinos_tests-thunk_tests/transaction_reversion
17/43 Test #25: koinos_tests-thunk_tests/db_crud ..................................   Passed    0.08 sec
      Start 20: koinos_tests-state_db_tests/rocksdb_backend_test
18/43 Test #16: koinos_tests-state_db_tests/merge_iterator ........................   Passed    0.27 sec
      Start 28: koinos_tests-thunk_tests/thunk_test
19/43 Test  #5: koinos_tests-controller_tests/transaction_reversion_test ..........   Passed    1.05 sec
      Start 35: koinos_tests-thunk_tests/check_authority
20/43 Test #40: koinos_tests-thunk_tests/transaction_reversion ....................   Passed    0.09 sec
      Start 33: koinos_tests-thunk_tests/last_irreversible_block_test
21/43 Test #20: koinos_tests-state_db_tests/rocksdb_backend_test ..................   Passed    0.10 sec
      Start 32: koinos_tests-thunk_tests/privileged_calls
22/43 Test #28: koinos_tests-thunk_tests/thunk_test ...............................   Passed    0.09 sec
      Start 29: koinos_tests-thunk_tests/system_call_test
23/43 Test #35: koinos_tests-thunk_tests/check_authority ..........................   Passed    0.08 sec
      Start 31: koinos_tests-thunk_tests/hash_thunk_test
24/43 Test #11: koinos_tests-stack_tests/syscall_override_from_thunk ..............   Passed    0.34 sec
      Start 42: koinos_tests-thunk_tests/get_chain_id
25/43 Test #32: koinos_tests-thunk_tests/privileged_calls .........................   Passed    0.08 sec
      Start 24: koinos_tests-thunk_tests/get_block_field
26/43 Test #26: koinos_tests-thunk_tests/contract_tests ...........................   Passed    0.32 sec
      Start 34: koinos_tests-thunk_tests/stack_tests
27/43 Test #29: koinos_tests-thunk_tests/system_call_test .........................   Passed    0.08 sec
      Start 36: koinos_tests-thunk_tests/transaction_nonce_test
28/43 Test #31: koinos_tests-thunk_tests/hash_thunk_test ..........................   Passed    0.08 sec
      Start 19: koinos_tests-state_db_tests/merkle_root_test
29/43 Test #33: koinos_tests-thunk_tests/last_irreversible_block_test .............   Passed    0.21 sec
      Start 21: koinos_tests-state_db_tests/rocksdb_object_cache_test
30/43 Test #19: koinos_tests-state_db_tests/merkle_root_test ......................   Passed    0.08 sec
      Start 23: koinos_tests-thunk_tests/get_transaction_field
31/43 Test #42: koinos_tests-thunk_tests/get_chain_id .............................   Passed    0.15 sec
      Start 37: koinos_tests-thunk_tests/get_contract_id_test
32/43 Test #24: koinos_tests-thunk_tests/get_block_field ..........................   Passed    0.13 sec
      Start 30: koinos_tests-thunk_tests/get_head_info_thunk_test
33/43 Test #21: koinos_tests-state_db_tests/rocksdb_object_cache_test .............   Passed    0.07 sec
      Start 22: koinos_tests-state_db_tests/map_backend_test
34/43 Test #23: koinos_tests-thunk_tests/get_transaction_field ....................   Passed    0.08 sec
      Start 18: koinos_tests-state_db_tests/anonymous_node_test
35/43 Test #34: koinos_tests-thunk_tests/stack_tests ..............................   Passed    0.21 sec
      Start 14: koinos_tests-state_db_tests/basic_test
36/43 Test #22: koinos_tests-state_db_tests/map_backend_test ......................   Passed    0.07 sec
37/43 Test #37: koinos_tests-thunk_tests/get_contract_id_test .....................   Passed    0.12 sec
38/43 Test #36: koinos_tests-thunk_tests/transaction_nonce_test ...................   Passed    0.24 sec
39/43 Test #18: koinos_tests-state_db_tests/anonymous_node_test ...................   Passed    0.07 sec
40/43 Test #30: koinos_tests-thunk_tests/get_head_info_thunk_test .................   Passed    0.14 sec
41/43 Test #14: koinos_tests-state_db_tests/basic_test ............................   Passed    0.07 sec
42/43 Test  #3: koinos_tests-controller_tests/fork_heads ..........................   Passed    1.49 sec
43/43 Test #43: koinos_tests-thunk_tests/thunk_time ...............................   Passed    2.95 sec

100% tests passed, 0 tests failed out of 43

Total Test time (real) =   2.96 sec
```
