### PR TITLE
Return the error message string from call

### DIFF
--- a/libraries/koinos_api_cpp/include/koinos/system/system_calls.hpp
+++ b/libraries/koinos_api_cpp/include/koinos/system/system_calls.hpp
@@ -1010,6 +1010,9 @@ inline std::pair< int32_t, std::string > call( const std::string& id, uint32_t e
       &bytes_written
    );
 
+   if ( retval )
+      return std::make_pair( retval, std::string( reinterpret_cast< const char* >( buffer.data() ), bytes_written ) );
+
    koinos::read_buffer rdbuf( detail::syscall_buffer.data(), bytes_written );
 
    koinos::chain::call_result< detail::max_argument_size > res;


### PR DESCRIPTION
## Brief description

Correctly returns the error message from `call`

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

