### PR TITLE
Update sdk to use updated error_data

### DIFF
--- a/libraries/koinos_api_cpp/include/koinos/token.hpp
+++ b/libraries/koinos_api_cpp/include/koinos/token.hpp
@@ -40,7 +40,7 @@ class token
          auto [ code, ret_value ] = system::call( _contract_address, detail::entries::name_entry, std::string() );
          if ( code != 0 )
             system::revert();
-         koinos::read_buffer buf( (uint8_t*)ret_value.data(), ret_value.size() );
+         koinos::read_buffer buf( (uint8_t*)ret_value.get_object().get_const(), ret_value.get_object().get_length() );
          detail::name_result res;
          res.deserialize( buf );
          return std::string( res.get_value().get_const(), res.get_value().get_length() );
@@ -51,7 +51,7 @@ class token
          auto [ code, ret_value ] = system::call( _contract_address, detail::entries::symbol_entry, std::string() );
          if ( code != 0 )
             system::revert();
-         koinos::read_buffer buf( (uint8_t*)ret_value.data(), ret_value.size() );
+         koinos::read_buffer buf( (uint8_t*)ret_value.get_object().get_const(), ret_value.get_object().get_length() );
          detail::symbol_result res;
          res.deserialize( buf );
          return std::string( res.get_value().get_const(), res.get_value().get_length() );
@@ -62,7 +62,7 @@ class token
          auto [ code, ret_value ] = system::call( _contract_address, detail::entries::decimals_entry, std::string() );
          if ( code != 0 )
             system::revert();
-         koinos::read_buffer buf( (uint8_t*)ret_value.data(), ret_value.size() );
+         koinos::read_buffer buf( (uint8_t*)ret_value.get_object().get_const(), ret_value.get_object().get_length() );
          koinos::contracts::token::decimals_result res;
          res.deserialize( buf );
          return res.get_value();
@@ -73,7 +73,7 @@ class token
          auto [ code, ret_value ] = system::call( _contract_address, detail::entries::total_supply_entry, std::string() );
          if ( code != 0 )
             system::revert();
-         koinos::read_buffer buf( (uint8_t*)ret_value.data(), ret_value.size() );
+         koinos::read_buffer buf( (uint8_t*)ret_value.get_object().get_const(), ret_value.get_object().get_length() );
          koinos::contracts::token::total_supply_result res;
          res.deserialize( buf );
          return res.get_value();
@@ -88,7 +88,7 @@ class token
          args.serialize( wbuf );
 
          auto [ code, ret_value ] = system::call( _contract_address, detail::entries::balance_of_entry, std::string( reinterpret_cast< char* >( wbuf.data() ), wbuf.get_size() ) );
-         koinos::read_buffer buf( (uint8_t*)ret_value.data(), ret_value.size() );
+         koinos::read_buffer buf( (uint8_t*)ret_value.get_object().get_const(), ret_value.get_object().get_length() );
          koinos::contracts::token::balance_of_result res;
          res.deserialize( buf );
          return res.get_value();
@@ -105,7 +105,9 @@ class token
          args.serialize( wbuf );
 
          auto [ code, ret_value ] = system::call( _contract_address, detail::entries::transfer_entry, std::string( reinterpret_cast< char* >( wbuf.data() ), wbuf.get_size() ) );
-         koinos::read_buffer buf( (uint8_t*)ret_value.data(), ret_value.size() );
+         if ( code != 0 )
+            system::revert();
+         koinos::read_buffer buf( (uint8_t*)ret_value.get_object().get_const(), ret_value.get_object().get_length() );
          koinos::contracts::token::transfer_result res;
          res.deserialize( buf );
          return res.get_value();
@@ -123,7 +125,7 @@ class token
          auto [ code, ret_value ] = system::call( _contract_address, detail::entries::mint_entry, std::string( reinterpret_cast< char* >( wbuf.data() ), wbuf.get_size() ) );
          if ( code != 0 )
             system::revert();
-         koinos::read_buffer buf( (uint8_t*)ret_value.data(), ret_value.size() );
+         koinos::read_buffer buf( (uint8_t*)ret_value.get_object().get_const(), ret_value.get_object().get_length() );
          koinos::contracts::token::mint_result res;
          res.deserialize( buf );
          return res.get_value();
@@ -141,7 +143,7 @@ class token
          auto [ code, ret_value ] = system::call( _contract_address, detail::entries::burn_entry, std::string( reinterpret_cast< char* >( wbuf.data() ), wbuf.get_size() ) );
          if ( code != 0 )
             system::revert();
-         koinos::read_buffer buf( (uint8_t*)ret_value.data(), ret_value.size() );
+         koinos::read_buffer buf( (uint8_t*)ret_value.get_object().get_const(), ret_value.get_object().get_length() );
          koinos::contracts::token::mint_result res;
          res.deserialize( buf );
          return res.get_value();


### PR DESCRIPTION
Resolves koinos/koinos-chain#696

## Brief description

`error_data` is now a part of a oneof in `result`. `call` and `exit`'s signatures changed as a result. This PR updates the SDK to interface correctly with those system calls and cleans up the contract facing API to more better interface with the system calls.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

Chain tests pass built when running contracts compiled with this branch of the SDK

```
ctest -j8
Test project /Users/mdv/git/koinos-chain/build/tests
      Start 47: koinos_tests-thunk_tests/thunk_time
      Start  3: koinos_tests-controller_tests/fork_heads
      Start  5: koinos_tests-controller_tests/transaction_reversion_test
      Start 42: koinos_tests-thunk_tests/authorize_tests
      Start  2: koinos_tests-controller_tests/block_irreversibility
      Start 38: koinos_tests-thunk_tests/token_tests
      Start 15: koinos_tests-state_db_tests/fork_tests
      Start  6: koinos_tests-controller_tests/receipt_test
 1/47 Test  #6: koinos_tests-controller_tests/receipt_test ........................   Passed    0.29 sec
      Start 45: koinos_tests-thunk_tests/system_rc
 2/47 Test #15: koinos_tests-state_db_tests/fork_tests ............................   Passed    0.41 sec
      Start 46: koinos_tests-thunk_tests/contract_exit
 3/47 Test #38: koinos_tests-thunk_tests/token_tests ..............................   Passed    0.54 sec
      Start 12: koinos_tests-stack_tests/syscall_override_from_syscall_override
 4/47 Test #45: koinos_tests-thunk_tests/system_rc ................................   Passed    0.22 sec
      Start  9: koinos_tests-stack_tests/syscall_from_user
 5/47 Test #42: koinos_tests-thunk_tests/authorize_tests ..........................   Passed    0.62 sec
      Start 10: koinos_tests-stack_tests/user_from_user
 6/47 Test  #2: koinos_tests-controller_tests/block_irreversibility ...............   Passed    0.71 sec
      Start 13: koinos_tests-stack_tests/system_contract_from_syscall_override
 7/47 Test #46: koinos_tests-thunk_tests/contract_exit ............................   Passed    0.25 sec
      Start  7: koinos_tests-controller_tests/system_call_override_test
 8/47 Test  #5: koinos_tests-controller_tests/transaction_reversion_test ..........   Passed    0.74 sec
      Start 11: koinos_tests-stack_tests/syscall_override_from_thunk
 9/47 Test #12: koinos_tests-stack_tests/syscall_override_from_syscall_override ...   Passed    0.18 sec
      Start  8: koinos_tests-stack_tests/simple_user_contract
10/47 Test  #9: koinos_tests-stack_tests/syscall_from_user ........................   Passed    0.25 sec
      Start  4: koinos_tests-controller_tests/read_contract_tests
11/47 Test #10: koinos_tests-stack_tests/user_from_user ...........................   Passed    0.33 sec
      Start 27: koinos_tests-thunk_tests/override_tests
12/47 Test  #7: koinos_tests-controller_tests/system_call_override_test ...........   Passed    0.24 sec
      Start 39: koinos_tests-thunk_tests/tick_limit
13/47 Test #13: koinos_tests-stack_tests/system_contract_from_syscall_override ....   Passed    0.25 sec
      Start 17: koinos_tests-state_db_tests/reset_test
14/47 Test #11: koinos_tests-stack_tests/syscall_override_from_thunk ..............   Passed    0.23 sec
      Start 16: koinos_tests-state_db_tests/merge_iterator
15/47 Test  #8: koinos_tests-stack_tests/simple_user_contract .....................   Passed    0.26 sec
      Start 26: koinos_tests-thunk_tests/contract_tests
16/47 Test #17: koinos_tests-state_db_tests/reset_test ............................   Passed    0.19 sec
      Start 40: koinos_tests-thunk_tests/disk_usage
17/47 Test  #4: koinos_tests-controller_tests/read_contract_tests .................   Passed    0.34 sec
      Start  1: koinos_tests-controller_tests/submission_tests
18/47 Test #27: koinos_tests-thunk_tests/override_tests ...........................   Passed    0.21 sec
      Start 36: koinos_tests-thunk_tests/transaction_nonce_test
19/47 Test #26: koinos_tests-thunk_tests/contract_tests ...........................   Passed    0.16 sec
      Start 20: koinos_tests-state_db_tests/rocksdb_backend_test
20/47 Test #39: koinos_tests-thunk_tests/tick_limit ...............................   Passed    0.31 sec
      Start 24: koinos_tests-thunk_tests/get_block_field
21/47 Test #40: koinos_tests-thunk_tests/disk_usage ...............................   Passed    0.11 sec
      Start 23: koinos_tests-thunk_tests/get_transaction_field
22/47 Test #36: koinos_tests-thunk_tests/transaction_nonce_test ...................   Passed    0.11 sec
      Start 43: koinos_tests-thunk_tests/get_chain_id
23/47 Test #20: koinos_tests-state_db_tests/rocksdb_backend_test ..................   Passed    0.11 sec
      Start 33: koinos_tests-thunk_tests/last_irreversible_block_test
24/47 Test #16: koinos_tests-state_db_tests/merge_iterator ........................   Passed    0.31 sec
      Start 31: koinos_tests-thunk_tests/hash_thunk_test
25/47 Test  #3: koinos_tests-controller_tests/fork_heads ..........................   Passed    1.29 sec
      Start 25: koinos_tests-thunk_tests/db_crud
26/47 Test  #1: koinos_tests-controller_tests/submission_tests ....................   Passed    0.14 sec
      Start 41: koinos_tests-thunk_tests/transaction_reversion
27/47 Test #43: koinos_tests-thunk_tests/get_chain_id .............................   Passed    0.14 sec
      Start 28: koinos_tests-thunk_tests/thunk_test
28/47 Test #24: koinos_tests-thunk_tests/get_block_field ..........................   Passed    0.15 sec
      Start 34: koinos_tests-thunk_tests/stack_tests
29/47 Test #31: koinos_tests-thunk_tests/hash_thunk_test ..........................   Passed    0.14 sec
      Start 35: koinos_tests-thunk_tests/check_authority
30/47 Test #33: koinos_tests-thunk_tests/last_irreversible_block_test .............   Passed    0.15 sec
      Start 37: koinos_tests-thunk_tests/get_contract_id_test
31/47 Test #25: koinos_tests-thunk_tests/db_crud ..................................   Passed    0.15 sec
      Start 32: koinos_tests-thunk_tests/privileged_calls
32/47 Test #23: koinos_tests-thunk_tests/get_transaction_field ....................   Passed    0.27 sec
      Start 30: koinos_tests-thunk_tests/get_head_info_thunk_test
33/47 Test #34: koinos_tests-thunk_tests/stack_tests ..............................   Passed    0.16 sec
      Start 29: koinos_tests-thunk_tests/system_call_test
34/47 Test #41: koinos_tests-thunk_tests/transaction_reversion ....................   Passed    0.28 sec
      Start 21: koinos_tests-state_db_tests/rocksdb_object_cache_test
35/47 Test #28: koinos_tests-thunk_tests/thunk_test ...............................   Passed    0.21 sec
      Start 19: koinos_tests-state_db_tests/merkle_root_test
36/47 Test #35: koinos_tests-thunk_tests/check_authority ..........................   Passed    0.24 sec
      Start 22: koinos_tests-state_db_tests/map_backend_test
37/47 Test #37: koinos_tests-thunk_tests/get_contract_id_test .....................   Passed    0.24 sec
      Start 44: koinos_tests-thunk_tests/system_resources
38/47 Test #32: koinos_tests-thunk_tests/privileged_calls .........................   Passed    0.24 sec
      Start 18: koinos_tests-state_db_tests/anonymous_node_test
39/47 Test #21: koinos_tests-state_db_tests/rocksdb_object_cache_test .............   Passed    0.10 sec
      Start 14: koinos_tests-state_db_tests/basic_test
40/47 Test #30: koinos_tests-thunk_tests/get_head_info_thunk_test .................   Passed    0.21 sec
41/47 Test #29: koinos_tests-thunk_tests/system_call_test .........................   Passed    0.18 sec
42/47 Test #22: koinos_tests-state_db_tests/map_backend_test ......................   Passed    0.10 sec
43/47 Test #18: koinos_tests-state_db_tests/anonymous_node_test ...................   Passed    0.09 sec
44/47 Test #14: koinos_tests-state_db_tests/basic_test ............................   Passed    0.08 sec
45/47 Test #44: koinos_tests-thunk_tests/system_resources .........................   Passed    0.10 sec
46/47 Test #19: koinos_tests-state_db_tests/merkle_root_test ......................   Passed    0.17 sec
47/47 Test #47: koinos_tests-thunk_tests/thunk_time ...............................   Passed    3.27 sec

100% tests passed, 0 tests failed out of 47

Total Test time (real) =   3.27 sec
```